### PR TITLE
Fixed: app crush on offline login/reg attempt

### DIFF
--- a/app/src/main/java/com/example/eventplannerteam22/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/eventplannerteam22/auth/login/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.example.eventplannerteam22.auth.login
 
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
@@ -21,6 +22,8 @@ import com.example.eventplannerteam22.network.ApiResult
 import com.example.eventplannerteam22.router.Screen
 import com.example.eventplannerteam22.session.SessionViewModel
 
+const val LOG_TAG = "LoginScreen"
+
 @Composable
 fun LoginScreen(
     navController: NavController,
@@ -35,29 +38,64 @@ fun LoginScreen(
         loginViewModel.apiResults.collect { result ->
             when (result) {
                 is ApiResult.Success -> {
+                    Log.w(LOG_TAG, "Successful login: ${result.data}")
                     sessionViewModel.updateState(
                         accessToken = result.data.accessToken,
                         refreshToken = result.data.refreshToken,
                         expiresIn = result.data.expiresIn,
                         loggedIn = true
                     )
-                    navController.navigate(Screen.MainScreen.route)
+                    navController.navigate(Screen.MainScreen.route) {
+                        popUpTo(Screen.LoginScreen.route) { inclusive = true }
+                    }
+                }
+
+                is ApiResult.BadRequest -> {
+                    Log.w(LOG_TAG, "BadRequest: ${result.message}")
+                    Toast.makeText(context, result.message ?: "Bad request", Toast.LENGTH_SHORT)
+                        .show()
                 }
 
                 is ApiResult.Unauthorized -> {
+                    Log.w(LOG_TAG, "Unauthorized: ${result.message}")
                     Toast.makeText(context, "Invalid email or password", Toast.LENGTH_SHORT).show()
                 }
 
-                is ApiResult.ServerError -> {
-                    Toast.makeText(context, "Server error occurred!", Toast.LENGTH_SHORT).show()
+                is ApiResult.Forbidden -> {
+                    Log.w(LOG_TAG, "Forbidden: ${result.message}")
+                    Toast.makeText(context, "Access denied", Toast.LENGTH_SHORT).show()
                 }
 
-                else -> {
+                is ApiResult.NotFound -> {
+                    Log.w(LOG_TAG, "NotFound: ${result.message}")
+                    Toast.makeText(context, "Resource not found", Toast.LENGTH_SHORT).show()
+                }
+
+                is ApiResult.Conflict -> {
+                    Log.w(LOG_TAG, "Conflict: ${result.message}")
+                    Toast.makeText(context, "Conflict occurred", Toast.LENGTH_SHORT).show()
+                }
+
+                is ApiResult.ServerError -> {
+                    Log.e(LOG_TAG, "ServerError ${result.code}: ${result.message}")
+                    Toast.makeText(context, "Server error (${result.code})", Toast.LENGTH_SHORT)
+                        .show()
+                }
+
+                is ApiResult.UnknownError -> {
+                    Log.e(LOG_TAG, "UnknownError ${result.code}: ${result.message}")
+                    Toast.makeText(context, "Unexpected error (${result.code})", Toast.LENGTH_SHORT)
+                        .show()
+                }
+
+                is ApiResult.ConnectionError -> {
+                    Log.e(LOG_TAG, "ConnectionError: ${result.message}")
                     Toast.makeText(
                         context,
-                        "Something is completely wrong here",
+                        "Connection error: (${result.message})",
                         Toast.LENGTH_SHORT
-                    ).show()
+                    )
+                        .show()
                 }
             }
         }
@@ -69,6 +107,7 @@ fun LoginScreen(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+
         ValidatingInputTextField(
             label = "Email",
             value = loginScreenState.email,
@@ -76,7 +115,9 @@ fun LoginScreen(
             isError = loginScreenState.emailErrorText != null,
             errorText = loginScreenState.emailErrorText
         )
+
         Spacer(modifier = Modifier.height(16.dp))
+
         ValidatingInputTextField(
             label = "Password",
             value = loginScreenState.password,
@@ -84,7 +125,9 @@ fun LoginScreen(
             isError = loginScreenState.passwordErrorText != null,
             errorText = loginScreenState.passwordErrorText
         )
+
         Spacer(modifier = Modifier.height(16.dp))
+
         Button(
             onClick = {
                 loginViewModel.onEvent(LoginUiEvent.Login)
@@ -94,6 +137,7 @@ fun LoginScreen(
             Text(text = "Sign in")
         }
     }
+
     if (loginScreenState.isLoading) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/example/eventplannerteam22/auth/registration/RegistrationScreen.kt
+++ b/app/src/main/java/com/example/eventplannerteam22/auth/registration/RegistrationScreen.kt
@@ -1,5 +1,6 @@
 package com.example.eventplannerteam22.auth.registration
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -25,6 +26,7 @@ import com.example.eventplannerteam22.auth.ValidatingInputTextField
 import com.example.eventplannerteam22.network.ApiResult
 import com.example.eventplannerteam22.router.Screen
 
+const val LOG_TAG = "RegistrationScreen"
 
 @Composable
 fun RegistrationScreen(
@@ -40,10 +42,37 @@ fun RegistrationScreen(
         viewModel.authResults.collect { result ->
             when (result) {
                 is ApiResult.Success -> {
-                    navController.navigate(Screen.MainScreen.route)
+                    Log.w(LOG_TAG, "Successful registration: ${result.data}")
+                    navController.navigate(Screen.MainScreen.route) {
+                        popUpTo(Screen.RegistrationScreen.route) {
+                            inclusive = true
+                        }
+                    }
+                }
+
+                is ApiResult.BadRequest -> {
+                    Log.w(LOG_TAG, "BadRequest: ${result.message}")
+                    Toast.makeText(context, result.message ?: "Bad request", Toast.LENGTH_SHORT)
+                        .show()
+                }
+
+                is ApiResult.Unauthorized -> {
+                    Log.w(LOG_TAG, "Unauthorized: ${result.message}")
+                    Toast.makeText(context, "Invalid email or password", Toast.LENGTH_SHORT).show()
+                }
+
+                is ApiResult.Forbidden -> {
+                    Log.w(LOG_TAG, "Forbidden: ${result.message}")
+                    Toast.makeText(context, "Access denied", Toast.LENGTH_SHORT).show()
+                }
+
+                is ApiResult.NotFound -> {
+                    Log.w(LOG_TAG, "NotFound: ${result.message}")
+                    Toast.makeText(context, "Resource not found", Toast.LENGTH_SHORT).show()
                 }
 
                 is ApiResult.Conflict -> {
+                    Log.w(LOG_TAG, "Conflict: ${result.message}")
                     Toast.makeText(
                         context,
                         "User with this email already exists",
@@ -52,6 +81,7 @@ fun RegistrationScreen(
                 }
 
                 is ApiResult.ServerError -> {
+                    Log.e(LOG_TAG, "ServerError ${result.code}: ${result.message}")
                     Toast.makeText(
                         context,
                         "Server error occurred! ${result.code}, ${result.message}",
@@ -59,10 +89,20 @@ fun RegistrationScreen(
                     ).show()
                 }
 
-                else -> {
+                is ApiResult.UnknownError -> {
+                    Log.e(LOG_TAG, "UnknownError ${result.code}: ${result.message}")
                     Toast.makeText(
                         context,
-                        "Something is really really bad here",
+                        "Unexpected error (${result.code})",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+
+                is ApiResult.ConnectionError -> {
+                    Log.e(LOG_TAG, "ConnectionError: ${result.message}")
+                    Toast.makeText(
+                        context,
+                        "Connection error: ${result.message}",
                         Toast.LENGTH_SHORT
                     ).show()
                 }

--- a/app/src/main/java/com/example/eventplannerteam22/network/ApiResult.kt
+++ b/app/src/main/java/com/example/eventplannerteam22/network/ApiResult.kt
@@ -3,10 +3,11 @@ package com.example.eventplannerteam22.network
 sealed class ApiResult<out T> {
     data class Success<out T>(val data: T) : ApiResult<T>()
     data class BadRequest(val message: String? = null) : ApiResult<Nothing>()
-    object Unauthorized : ApiResult<Nothing>()
-    object Forbidden : ApiResult<Nothing>()
-    object NotFound : ApiResult<Nothing>()
-    object Conflict : ApiResult<Nothing>()
+    data class Unauthorized(val message: String? = null) : ApiResult<Nothing>()
+    data class Forbidden(val message: String? = null) : ApiResult<Nothing>()
+    data class NotFound(val message: String? = null) : ApiResult<Nothing>()
+    data class Conflict(val message: String? = null) : ApiResult<Nothing>()
     data class ServerError(val code: Int, val message: String? = null) : ApiResult<Nothing>()
-    data class UnknownError(val code: Int, val message: String? = null): ApiResult<Nothing>()
+    data class UnknownError(val code: Int, val message: String? = null) : ApiResult<Nothing>()
+    data class ConnectionError(val message: String? = null) : ApiResult<Nothing>()
 }

--- a/app/src/main/java/com/example/eventplannerteam22/network/safeApiCall.kt
+++ b/app/src/main/java/com/example/eventplannerteam22/network/safeApiCall.kt
@@ -1,18 +1,22 @@
 package com.example.eventplannerteam22.network
 
 import retrofit2.HttpException
+import java.net.ConnectException
+
 suspend fun <T> safeApiCall(apiCall: suspend () -> T): ApiResult<T> {
     return try {
         ApiResult.Success(apiCall())
-    } catch (e: HttpException){
-        when(e.code()){
+    } catch (e: HttpException) {
+        when (e.code()) {
             400 -> ApiResult.BadRequest(e.message())
-            401 -> ApiResult.Unauthorized
-            403 -> ApiResult.Forbidden
-            404 -> ApiResult.NotFound
-            409 -> ApiResult.Conflict
+            401 -> ApiResult.Unauthorized(e.message())
+            403 -> ApiResult.Forbidden(e.message())
+            404 -> ApiResult.NotFound(e.message())
+            409 -> ApiResult.Conflict(e.message())
             in 500..599 -> ApiResult.ServerError(e.code(), e.message())
             else -> ApiResult.UnknownError(e.code(), e.message())
         }
+    } catch (e: ConnectException) {
+        ApiResult.ConnectionError(e.message ?: "Failed to connect to the server")
     }
 }


### PR DESCRIPTION
**Fixed:**
- app crash on a login/register attempt while app or server is offline

**Added:**
- `ApiResult` subclass for `ConnectionException`
- message field to every `ApiResult` sub class

**Updated:**
- `LoginScreen` and `RegistrationScreen` to handle any possible `ApiResult`, throw a `Toast` and Log everything to a Logcat