### PR TITLE
Updatede: auth screen to have different keyboard on an email field

### DIFF
--- a/app/src/main/java/com/example/eventplannerteam22/auth/AuthScreen.kt
+++ b/app/src/main/java/com/example/eventplannerteam22/auth/AuthScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -25,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -100,7 +102,8 @@ fun AuthScreen(
                 value = loginState.email,
                 onValueChange = { loginViewModel.onEvent(LoginUiEvent.EmailChanged(it)) },
                 isError = loginState.emailErrorText != null,
-                errorText = loginState.emailErrorText
+                errorText = loginState.emailErrorText,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
             )
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -161,7 +164,8 @@ fun AuthScreen(
                     )
                 },
                 isError = registrationState.emailErrorText != null,
-                errorText = registrationState.emailErrorText
+                errorText = registrationState.emailErrorText,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
             )
             Spacer(modifier = Modifier.height(16.dp))
 


### PR DESCRIPTION
### Updated:
- `AuthScreen`
   - email field is using `KeyboardType.Email`