### PR TITLE
sesion now stores user id

### DIFF
--- a/app/src/main/java/com/example/eventplannerteam22/session/Session.kt
+++ b/app/src/main/java/com/example/eventplannerteam22/session/Session.kt
@@ -7,7 +7,8 @@ data class Session(
     val refreshToken: String = "",
     val expiresIn: Long = 0L,
     val loggedIn: Boolean = false,
-    val userRole: UserRole? = null
+    val userRole: UserRole? = null,
+    val userId: Int? = null
 ) {
     override fun toString(): String {
         return buildString {

--- a/app/src/main/java/com/example/eventplannerteam22/session/SessionViewModel.kt
+++ b/app/src/main/java/com/example/eventplannerteam22/session/SessionViewModel.kt
@@ -44,13 +44,15 @@ class SessionViewModel @Inject constructor(
                     Authority::class.java
                 )[0]
         )
+        val id = JWT.decode(tokenResponse.accessToken).getClaim("userId").asInt()
         _session.update {
             it.copy(
                 accessToken = tokenResponse.accessToken,
                 refreshToken = tokenResponse.refreshToken,
                 expiresIn = tokenResponse.expiresIn,
                 loggedIn = true,
-                userRole = role
+                userRole = role,
+                userId = id
             )
         }
         Log.i(logTag, session.value.toString())
@@ -63,7 +65,8 @@ class SessionViewModel @Inject constructor(
                 refreshToken = "",
                 expiresIn = 0L,
                 loggedIn = false,
-                userRole = null
+                userRole = null,
+                userId = null
             )
         }
     }


### PR DESCRIPTION
### Modified:
- `Session.kt`
   - now includes `userId`
- `SessionViewModel.kt`
   - gets `userId` from the jwt token